### PR TITLE
Make bucket transport serializable

### DIFF
--- a/lets/src/address.rs
+++ b/lets/src/address.rs
@@ -68,7 +68,7 @@ use crate::{
 /// you can also use `{:x?}` or `{:#x?}` to render them as hexadecimal arrays.
 ///
 /// [Display]: #impl-Display
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash, serde::Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Address {
     /// The base address of the application
     appaddr: AppAddr,
@@ -154,7 +154,7 @@ impl FromStr for Address {
 }
 
 /// 40 byte Application Instance identifier.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 
 pub struct AppAddr(#[serde(with = "BigArray")] [u8; Self::SIZE]);
 
@@ -239,7 +239,7 @@ impl From<[u8; 40]> for AppAddr {
 }
 
 /// 12 byte Message Identifier unique within the same application.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MsgId([u8; Self::SIZE]);
 
 impl MsgId {

--- a/lets/src/message/transport.rs
+++ b/lets/src/message/transport.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Binary network Message representation.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, serde::Serialize, serde::Deserialize)]
 pub struct TransportMessage{
     body: Vec<u8>,
     pk: Vec<u8>,

--- a/lets/src/transport/bucket.rs
+++ b/lets/src/transport/bucket.rs
@@ -3,6 +3,7 @@ use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
 // 3rd-party
 use async_trait::async_trait;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 // IOTA
 
@@ -96,5 +97,21 @@ where
             .get(&address)
             .cloned()
             .ok_or(Error::AddressError("No message found", address))
+    }
+}
+
+impl<Msg: Serialize> Serialize for Client<Msg> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let bucket = self.bucket.lock();
+        bucket.serialize(serializer)
+    }
+}
+
+impl<'de, Msg: Deserialize<'de>> Deserialize<'de> for Client<Msg> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let bucket: BTreeMap<Address, Vec<Msg>> = Deserialize::deserialize(deserializer)?;
+        Ok(Client {
+            bucket: Arc::new(spin::Mutex::new(bucket)),
+        })
     }
 }


### PR DESCRIPTION
Serialize the bucket client to allow it to be stored and retrieved from db's for application purposes.