### PR TITLE
feat: identity doc caching

### DIFF
--- a/lets/benches/tangle_clients.rs
+++ b/lets/benches/tangle_clients.rs
@@ -34,7 +34,7 @@ where
             Utc::now().timestamp_millis() as usize,
         ),
     );
-    client.send_message(address, msg).await?;
+    //client.send_message(address, msg).await?;
     Ok(())
 }
 
@@ -74,7 +74,7 @@ fn bench_clients(c: &mut Criterion) {
 struct Ignore {}
 
 impl TryFrom<Message> for Ignore {
-    type Error = create::error::Error;
+    type Error = crate::error::Error;
     fn try_from(_: Message) -> Result<Self, Self::Error> {
         Ok(Ignore {})
     }

--- a/lets/src/address.rs
+++ b/lets/src/address.rs
@@ -159,7 +159,6 @@ impl FromStr for Address {
 /// 40 byte Application Instance identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-
 pub struct AppAddr(#[serde(with = "BigArray")] [u8; Self::SIZE]);
 
 impl AppAddr {
@@ -208,7 +207,7 @@ impl FromStr for AppAddr {
 /// Display appaddr with its hexadecimal representation (lower case)
 impl Display for AppAddr {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self)
+        write!(f, "{self:x}")
     }
 }
 
@@ -289,7 +288,7 @@ impl FromStr for MsgId {
 /// Display MsgId with its hexadecimal representation (lower case)
 impl Display for MsgId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self)
+        write!(f, "{self:x}")
     }
 }
 

--- a/lets/src/error.rs
+++ b/lets/src/error.rs
@@ -122,7 +122,7 @@ pub enum Error {
 
     #[cfg(any(feature = "tangle-client", feature = "tangle-client-wasm"))]
     #[error("Iota client error for {0}: {1}")]
-    IotaClient(&'static str, iota_sdk::client::Error),
+    IotaClient(&'static str, Box<iota_sdk::client::Error>),
 
     #[cfg(feature = "mysql-client")]
     #[error("MySql client error for {0}: {1}")]

--- a/lets/src/id/cache.rs
+++ b/lets/src/id/cache.rs
@@ -1,0 +1,14 @@
+use identity_demia::demia::{DemiaDID, DemiaDocument};
+
+#[cfg(feature = "did")]
+#[async_trait::async_trait]
+pub trait IdentityCache {
+    /// Returns the `DID` document for the given `DID`.
+    async fn get_did_document(&self, did: &DemiaDID) -> Option<DemiaDocument>;
+    
+    /// Sets the `DID` document for the given `DID`.
+    async fn set_did_document(&mut self, did: DemiaDID, document: DemiaDocument);
+    
+    /// Checks size of cache
+    async fn size(&self) -> usize;
+}

--- a/lets/src/id/cache.rs
+++ b/lets/src/id/cache.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "did")]
 use identity_demia::demia::{DemiaDID, DemiaDocument};
 
 #[cfg(feature = "did")]
@@ -5,10 +6,10 @@ use identity_demia::demia::{DemiaDID, DemiaDocument};
 pub trait IdentityCache {
     /// Returns the `DID` document for the given `DID`.
     async fn get_did_document(&self, did: &DemiaDID) -> Option<DemiaDocument>;
-    
+
     /// Sets the `DID` document for the given `DID`.
     async fn set_did_document(&mut self, did: DemiaDID, document: DemiaDocument);
-    
+
     /// Checks size of cache
     async fn size(&self) -> usize;
 }

--- a/lets/src/id/did/did.rs
+++ b/lets/src/id/did/did.rs
@@ -1,13 +1,15 @@
+use core::fmt::Debug;
 // Rust
 use core::hash::Hash;
-
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 // IOTA
 use identity_demia::{
     demia::{DemiaDID, DemiaDocument, IotaIdentityClientExt},
     verification::VerificationMethod,
 };
 use iota_sdk::client::Client as DIDClient;
-
+use tokio::sync::RwLock;
 // Streams
 use spongos::{
     ddml::{
@@ -23,29 +25,36 @@ use crate::{
     error::{Error, Result},
     id::did::DIDUrlInfo,
 };
+use crate::id::cache::IdentityCache;
 
 /// Fetch the `DID` document from the tangle
 ///
 /// # Arguments
 /// * `url_info`: The document details
-pub(crate) async fn resolve_document(url_info: &DIDUrlInfo) -> Result<DemiaDocument> {
+/// * `cache`: The cache to use for storing and retrieving documents
+pub(crate) async fn resolve_document<C: IdentityCache>(url_info: &DIDUrlInfo, cache: &mut C) -> Result<DemiaDocument> {
     let did_url = DemiaDID::parse(url_info.did()).map_err(|e| Error::did("parse did url", e))?;
-    let client = DIDClient::builder()
-        .with_primary_node(url_info.client_url(), None)
-        .map_err(|e| Error::did("DIDClient set primary node", e))?
-        .finish()
-        .await
-        .map_err(|e| Error::did("build DID Client", e))?;
-    let doc = client
-        .resolve_did(&did_url)
-        .await
-        .map_err(|e| Error::did("read DID document", e))?;
-    Ok(doc)
+    if let Some(doc) = cache.get_did_document(&did_url).await {
+        Ok(doc.clone())
+    } else {
+        let client = DIDClient::builder()
+            .with_primary_node(url_info.client_url(), None)
+            .map_err(|e| Error::did("DIDClient set primary node", e))?
+            .finish()
+            .await
+            .map_err(|e| Error::did("build DID Client", e))?;
+        let doc = client
+            .resolve_did(&did_url)
+            .await
+            .map_err(|e| Error::did("read DID document", e))?;
+        cache.set_did_document(did_url, doc.clone()).await;
+        Ok(doc)
+    }
 }
 
-pub(crate) async fn get_exchange_method(info: &DIDUrlInfo) -> SpongosResult<VerificationMethod> {
+pub(crate) async fn get_exchange_method<C: IdentityCache>(info: &DIDUrlInfo, cache: &mut C) -> SpongosResult<VerificationMethod> {
     let exchange_fragment = info.exchange_fragment().to_string();
-    let doc = resolve_document(info)
+    let doc = resolve_document(info, cache)
         .await
         .map_err(|e| SpongosError::Context("ContentEncrypt", e.to_string()))?;
     doc.resolve_method(&exchange_fragment, None)
@@ -146,6 +155,47 @@ impl DIDInfo {
         &mut self.url_info
     }
 }
+
+#[derive(Default, Clone)]
+pub struct IdentityDocCache {
+    pub docs: Arc<RwLock<HashMap<DemiaDID, DemiaDocument>>>,
+}
+
+#[async_trait::async_trait]
+impl IdentityCache for IdentityDocCache {
+    async fn get_did_document(&self, did: &DemiaDID) -> Option<DemiaDocument> {
+        self.docs.read().await.get(&did).map(|doc| doc.clone())
+    }
+    
+    async fn set_did_document(&mut self, did: DemiaDID, doc: DemiaDocument) {
+        let _ = self.docs.write().await.insert(did, doc);
+    }
+    
+    async fn size(&self) -> usize {
+        self.docs.read().await.len()
+    }
+}
+
+impl PartialEq for IdentityDocCache {
+    fn eq(&self, other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for IdentityDocCache {}
+
+impl Hash for IdentityDocCache {
+    fn hash<H: core::hash::Hasher>(&self, _state: &mut H) {
+        ()
+    }
+}
+
+impl Debug for IdentityDocCache {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("IdentityDocCache")
+    }
+}
+
 
 /*
 /// Wrapper for a `DID` based KeyPair

--- a/lets/src/id/did/mod.rs
+++ b/lets/src/id/did/mod.rs
@@ -4,7 +4,7 @@ mod did;
 mod url_info;
 ///
 //mod keypair;
-pub use did::{DIDInfo, DID, IdentityDocCache};
+pub use did::{DIDInfo, IdentityDocCache, DID};
 pub use url_info::DIDUrlInfo;
 //pub use keypair::{KeyPair};
 

--- a/lets/src/id/did/mod.rs
+++ b/lets/src/id/did/mod.rs
@@ -4,7 +4,7 @@ mod did;
 mod url_info;
 ///
 //mod keypair;
-pub use did::{DIDInfo, DID};
+pub use did::{DIDInfo, DID, IdentityDocCache};
 pub use url_info::DIDUrlInfo;
 //pub use keypair::{KeyPair};
 

--- a/lets/src/id/did/url_info.rs
+++ b/lets/src/id/did/url_info.rs
@@ -27,6 +27,7 @@ use spongos::{
     error::{Error as SpongosError, Result as SpongosResult},
     PRP,
 };
+use crate::id::cache::IdentityCache;
 
 /// `DID` Document details
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -173,13 +174,14 @@ impl DIDUrlInfo {
     /// * `signing_fragment`: Label for exchange key methods
     /// * `signature_bytes`: Raw bytes for signature
     /// * `hash`: Hash value used for signature
-    pub(crate) async fn verify(
+    pub(crate) async fn verify<C: IdentityCache>(
         &self,
         signing_fragment: &str,
         signature_bytes: &[u8],
         hash: &[u8],
+        cache: &mut C,
     ) -> Result<()> {
-        let doc = super::resolve_document(self).await?;
+        let doc = super::resolve_document(self, cache).await?;
         let method = doc.resolve_method(signing_fragment, None).unwrap();
         match method.data() {
             MethodData::PublicKeyMultibase(pk) => {

--- a/lets/src/id/did/url_info.rs
+++ b/lets/src/id/did/url_info.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 // Streams
+use crate::id::cache::IdentityCache;
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Mask},
@@ -27,7 +28,6 @@ use spongos::{
     error::{Error as SpongosError, Result as SpongosResult},
     PRP,
 };
-use crate::id::cache::IdentityCache;
 
 /// `DID` Document details
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/lets/src/id/identifier.rs
+++ b/lets/src/id/identifier.rs
@@ -53,6 +53,8 @@ use crate::{
     error::Result,
     message::{ContentEncrypt, ContentEncryptSizeOf, ContentVerify},
 };
+use crate::id::cache::IdentityCache;
+use crate::id::did::IdentityDocCache;
 
 /// User Identification types
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -95,7 +97,8 @@ impl Identifier {
             Identifier::Ed25519(pk) => Ok(*pk),
             #[cfg(feature = "did")]
             Identifier::DID(url_info) => {
-                let doc = resolve_document(url_info).await?;
+                let mut cache = IdentityDocCache::default();
+                let doc = resolve_document(url_info, &mut cache).await?;
                 match doc.resolve_method(url_info.signing_fragment(), None) {
                     Some(sig) => {
                         let mut bytes = [0u8; 32];
@@ -128,7 +131,8 @@ impl Identifier {
                 .expect("failed to convert ed25519 public-key to x25519 public-key")),
             #[cfg(feature = "did")]
             Identifier::DID(url_info) => {
-                let doc = resolve_document(url_info).await?;
+                let mut cache = IdentityDocCache::default();
+                let doc = resolve_document(url_info, &mut cache).await?;
                 match doc.resolve_method(
                     url_info.exchange_fragment(),
                     Some(identity_demia::verification::MethodScope::key_agreement()),
@@ -266,6 +270,7 @@ where
     }
 }
 
+#[cfg(not(feature = "did"))]
 #[async_trait]
 impl<IS, F> ContentVerify<Identifier> for unwrap::Context<IS, F>
 where
@@ -292,14 +297,47 @@ where
                         .ed25519(public_key, hash.as_ref())?;
                     Ok(self)
                 }
-                #[cfg(feature = "did")]
+            },
+            o => Err(SpongosError::InvalidOption("identity", o)),
+        }
+    }
+}
+
+#[cfg(feature = "did")]
+#[async_trait]
+impl<IS, F, C> ContentVerify<Identifier, C> for unwrap::Context<IS, F>
+where
+    F: PRP + Send,
+    IS: io::IStream + Send,
+    C: IdentityCache + Send,
+{
+    /// Verifies the signature of the message based on the type of [`Identifier`] of the signing
+    /// user. If the sender [`Identifier`] is of type [`Identifier::Ed25519`], then the public
+    /// key is used to verify the message signature. If it is of type [`Identifier::DID`], then
+    /// the `DID` document is retrieved and the signature is verified using the appropriately
+    /// tagged `Verification Method`.
+    ///
+    /// # Arguments
+    /// * `verifier`: The [`Identifier`] of the signer.
+    #[cfg(feature = "did")]
+    async fn verify(&mut self, verifier: &Identifier, cache: &mut C) -> SpongosResult<&mut Self> {
+        let mut oneof = Uint8::default();
+        self.absorb(&mut oneof)?;
+        match oneof.inner() {
+            0 => match verifier {
+                Identifier::Ed25519(public_key) => {
+                    let mut hash = External::new(NBytes::new([0; 64]));
+                    self.commit()?
+                        .squeeze(hash.as_mut())?
+                        .ed25519(public_key, hash.as_ref())?;
+                    Ok(self)
+                }
                 o => Err(SpongosError::InvalidAction(
                     "verify data",
                     o.to_string(),
                     verifier.to_string(),
                 )),
             },
-            #[cfg(feature = "did")]
             1 => match verifier {
                 Identifier::DID(url_info) => {
                     let mut hash = [0; 64];
@@ -320,12 +358,12 @@ where
                                 verifier.to_string(),
                                 "Fragment bytes cant be converted to string".to_string()
                             )
-                            .to_string()
+                                .to_string()
                         ))?
                     );
 
                     url_info
-                        .verify(&signing_fragment, &signature_bytes, &hash)
+                        .verify(&signing_fragment, &signature_bytes, &hash, cache)
                         .await
                         .map_err(|e| SpongosError::Context("ContentVerify", e.to_string()))?;
                     Ok(self)
@@ -386,10 +424,11 @@ where
 
 #[cfg(feature = "did")]
 #[async_trait]
-impl<OS, F> ContentEncrypt<IdentityKind, Identifier> for wrap::Context<OS, F>
+impl<OS, F, C> ContentEncrypt<IdentityKind, Identifier, C> for wrap::Context<OS, F>
 where
     F: PRP,
     OS: io::OStream,
+    C: IdentityCache + Send + Sync,
 {
     #[cfg(feature = "did")]
     async fn encrypt(
@@ -397,14 +436,15 @@ where
         sender: &mut IdentityKind,
         recipient: &mut Identifier,
         key: &[u8],
+        cache: &mut C,
     ) -> SpongosResult<&mut Self> {
         match recipient {
             Identifier::DID(ref mut url_info) => {
                 match sender {
                     IdentityKind::DID(ref mut sender_info) => {
-                        let receiver_method = get_exchange_method(url_info).await?;
+                        let receiver_method = get_exchange_method(url_info, cache).await?;
                         let sender_method =
-                            get_exchange_method(sender_info.info().url_info()).await?;
+                            get_exchange_method(sender_info.info().url_info(), cache).await?;
 
                         //  The location of sender's xkeys in stronghold
                         let sender_location =
@@ -431,7 +471,7 @@ where
 
                         // Create an AEAD Encryption packet to be received and processed by the recipient
                         let encrypted_data = stronghold
-                            .write()
+                            .read()
                             .await
                             .x25519_encrypt(xkey, sender_location, key.to_vec())
                             .await
@@ -443,7 +483,7 @@ where
                             .mask(NBytes::new(&encrypted_data.ciphertext))
                     }
                     IdentityKind::Ed25519(kp) => {
-                        let receiver_method = get_exchange_method(url_info).await?;
+                        let receiver_method = get_exchange_method(url_info, cache).await?;
 
                         let xkey = x25519::PublicKey::try_from_slice(
                             &receiver_method.data().try_decode().map_err(|e| {

--- a/lets/src/id/identifier.rs
+++ b/lets/src/id/identifier.rs
@@ -49,12 +49,15 @@ use crate::{
     },
 };
 
+#[cfg(feature = "did")]
+use crate::{
+    id::{cache::IdentityCache, did::IdentityDocCache}
+};
+
 use crate::{
     error::Result,
     message::{ContentEncrypt, ContentEncryptSizeOf, ContentVerify},
 };
-use crate::id::cache::IdentityCache;
-use crate::id::did::IdentityDocCache;
 
 /// User Identification types
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -358,7 +361,7 @@ where
                                 verifier.to_string(),
                                 "Fragment bytes cant be converted to string".to_string()
                             )
-                                .to_string()
+                            .to_string()
                         ))?
                     );
 

--- a/lets/src/id/identity.rs
+++ b/lets/src/id/identity.rs
@@ -40,14 +40,13 @@ use crate::id::{ed25519::Ed25519, Ed25519Sig};
 use crate::{
     alloc::string::ToString,
     error::Error,
-    id::did::{get_exchange_method, DID, STREAMS_VAULT},
+    id::{cache::IdentityCache, did::{get_exchange_method, DID, STREAMS_VAULT}},
 };
 
 use crate::{
     id::identifier::Identifier,
     message::{ContentDecrypt, ContentSign, ContentSignSizeof},
 };
-use crate::id::cache::IdentityCache;
 
 /// Wrapper around [`Identifier`], specifying which type of [`Identity`] is being used. An
 /// [`Identity`] is the foundation of message sending and verification.
@@ -203,7 +202,7 @@ impl IdentityKind {
 
                 let lock = stronghold.read().await;
                 // update stronghold snapshot
-                
+
                 let location = Location::generic(STREAMS_VAULT, method.to_string().as_bytes());
                 let sig = lock
                     .ed25519_sign(location, data)
@@ -360,7 +359,7 @@ where
 
                         let lock = stronghold.read().await;
                         // update stronghold snapshot
-                        
+
                         let location =
                             Location::generic(STREAMS_VAULT, method.to_string().as_bytes());
                         let sig = lock
@@ -377,11 +376,10 @@ where
     }
 }
 
-
 #[cfg(not(feature = "did"))]
 #[async_trait]
-impl<IS, F> ContentDecrypt<IdentityKind> for wrap::Context<IS, F>
-where 
+impl<IS, F> ContentDecrypt<IdentityKind> for unwrap::Context<IS, F>
+where
     F: PRP + Send,
     IS: io::IStream + Send,
 {

--- a/lets/src/id/mod.rs
+++ b/lets/src/id/mod.rs
@@ -16,3 +16,4 @@ pub use psk::{Psk, PskId};
 /// Iota Identity functions and types
 #[cfg(feature = "did")]
 pub mod did;
+pub mod cache;

--- a/lets/src/id/mod.rs
+++ b/lets/src/id/mod.rs
@@ -13,7 +13,7 @@ pub use identifier::Identifier;
 pub use permission::{PermissionDuration, PermissionType, Permissioned};
 pub use psk::{Psk, PskId};
 
+pub mod cache;
 /// Iota Identity functions and types
 #[cfg(feature = "did")]
 pub mod did;
-pub mod cache;

--- a/lets/src/message/content.rs
+++ b/lets/src/message/content.rs
@@ -75,8 +75,13 @@ pub trait ContentEncrypt<T> {
 /// Used to encrypt a key slice for recipient `T` using Identity `I`
 #[async_trait]
 pub trait ContentEncrypt<I, T, C> {
-    async fn encrypt(&mut self, sender: &mut I, recipient: &mut T, key: &[u8], cache: &mut C)
-        -> Result<&mut Self>;
+    async fn encrypt(
+        &mut self,
+        sender: &mut I,
+        recipient: &mut T,
+        key: &[u8],
+        cache: &mut C,
+    ) -> Result<&mut Self>;
 }
 
 /// Used to decrypt a key slice for recipient `T`
@@ -89,6 +94,10 @@ pub trait ContentDecrypt<T> {
 #[cfg(feature = "did")]
 #[async_trait]
 pub trait ContentDecrypt<T, C> {
-    async fn decrypt(&mut self, recipient: &mut T, key: &mut [u8], cache: &mut C)
-        -> Result<&mut Self>;
+    async fn decrypt(
+        &mut self,
+        recipient: &mut T,
+        key: &mut [u8],
+        cache: &mut C,
+    ) -> Result<&mut Self>;
 }

--- a/lets/src/message/content.rs
+++ b/lets/src/message/content.rs
@@ -45,9 +45,16 @@ pub trait ContentSign<T> {
 }
 
 /// Used to authenticate the signature from the `Context` stream
+#[cfg(not(feature = "did"))]
 #[async_trait]
 pub trait ContentVerify<T> {
     async fn verify(&mut self, verifier: &T) -> Result<&mut Self>;
+}
+
+#[cfg(feature="did")]
+#[async_trait]
+pub trait ContentVerify<T, C> {
+    async fn verify(&mut self, verifier: &T, cache: &mut C) -> Result<&mut Self>;
 }
 
 /// Used to determine the encoding size of the encryption operation for a key slice for recipient
@@ -67,13 +74,21 @@ pub trait ContentEncrypt<T> {
 #[cfg(feature = "did")]
 /// Used to encrypt a key slice for recipient `T` using Identity `I`
 #[async_trait]
-pub trait ContentEncrypt<I, T> {
-    async fn encrypt(&mut self, sender: &mut I, recipient: &mut T, key: &[u8])
+pub trait ContentEncrypt<I, T, C> {
+    async fn encrypt(&mut self, sender: &mut I, recipient: &mut T, key: &[u8], cache: &mut C)
         -> Result<&mut Self>;
 }
 
 /// Used to decrypt a key slice for recipient `T`
+#[cfg(not(feature = "did"))]
 #[async_trait]
 pub trait ContentDecrypt<T> {
     async fn decrypt(&mut self, recipient: &mut T, key: &mut [u8]) -> Result<&mut Self>;
+}
+
+#[cfg(feature = "did")]
+#[async_trait]
+pub trait ContentDecrypt<T, C> {
+    async fn decrypt(&mut self, recipient: &mut T, key: &mut [u8], cache: &mut C)
+        -> Result<&mut Self>;
 }

--- a/lets/src/message/hdf.rs
+++ b/lets/src/message/hdf.rs
@@ -88,8 +88,7 @@ impl HDF {
     pub fn new(message_type: u8, sequence: usize, publisher: Identifier, topic: &Topic) -> Self {
         debug_assert!(
             message_type >> 4 == 0,
-            "invalid content-type '{}': content-type value cannot be greater than 4 bits",
-            message_type
+            "invalid content-type '{message_type}': content-type value cannot be greater than 4 bits"
         );
         Self {
             encoding: UTF8,

--- a/lets/src/transport/utangle.rs
+++ b/lets/src/transport/utangle.rs
@@ -80,7 +80,7 @@ impl<Message, SendResponse> Client<Message, SendResponse> {
         let network_info_path = "api/core/v2/info";
         let network_info: NetworkInfo = self
             .client
-            .get(format!("{}/{}", self.node_url, network_info_path))
+            .get(format!("{}/{network_info_path}", self.node_url))
             .send()
             .await?
             .json()
@@ -93,7 +93,7 @@ impl<Message, SendResponse> Client<Message, SendResponse> {
         let tips_path = "api/core/v2/tips";
         let tips: Tips = self
             .client
-            .get(format!("{}/{}", self.node_url, tips_path))
+            .get(format!("{}/{tips_path}", self.node_url))
             .send()
             .await?
             .json()
@@ -146,7 +146,7 @@ where
 
         let response: SendResponse = self
             .client
-            .post(format!("{}/{}", self.node_url, path))
+            .post(format!("{}/{path}", self.node_url))
             .header("Content-Type", "application/json")
             .body(message_bytes)
             .send()
@@ -168,7 +168,7 @@ where
         );
         let index_data: BlockResponse = self
             .client
-            .get(format!("{}/{}", self.node_url, path))
+            .get(format!("{}/{path}", self.node_url))
             .send()
             .await?
             .json()

--- a/spongos/src/core/tests.rs
+++ b/spongos/src/core/tests.rs
@@ -7,7 +7,7 @@ use super::{
 
 fn bytes_spongosn<F: PRP + Default>(n: usize) {
     let mut rng = Spongos::<F>::init();
-    rng.absorb(&vec![0; 10]);
+    rng.absorb(vec![0; 10]);
     rng.commit();
     let mut k = vec![0; n];
     let mut p = vec![0; n];
@@ -42,8 +42,8 @@ fn bytes_spongosn<F: PRP + Default>(n: usize) {
     assert!(s.squeeze_eq(&t2));
     assert!(s.squeeze_eq(&t3));
 
-    assert!(x == z, "{}: x != D(E(x))", n);
-    assert!(t == u, "{}: MAC(x) != MAC(D(E(x)))", n);
+    assert_eq!(x, z, "{n}: x != D(E(x))");
+    assert_eq!(t, u, "{n}: MAC(x) != MAC(D(E(x)))");
 }
 
 fn slice_spongosn<F: PRP + Default>(n: usize) {
@@ -83,8 +83,8 @@ fn slice_spongosn<F: PRP + Default>(n: usize) {
     assert!(s.squeeze_eq(&t23[..n]));
     assert!(s.squeeze_eq(&t23[n..]));
 
-    assert!(x == z, "{}: x != D(E(x))", n);
-    assert!(t == u, "{}: MAC(x) != MAC(D(E(x)))", n);
+    assert!(x == z, "{n}: x != D(E(x))");
+    assert!(t == u, "{n}: MAC(x) != MAC(D(E(x)))");
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn slices_with_size_boundary_cases() {
 
 fn encrypt_decrypt_n<F: PRP + Default + Clone>(n: usize) {
     let mut s = Spongos::<F>::init();
-    s.absorb(&vec![1; 32]);
+    s.absorb(vec![1; 32]);
     s.commit();
 
     let mut x = vec![0; n];

--- a/spongos/src/ddml/commands/sizeof/x25519.rs
+++ b/spongos/src/ddml/commands/sizeof/x25519.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Increases [`Context`] size by the x25519 Public Key Length (32 Bytes) as well as the number of
 /// bytes present in the [`NBytes`] wrapper.
-impl<'a, T: AsRef<[u8]>> X25519<&'a x25519::PublicKey, NBytes<T>> for Context {
+impl<T: AsRef<[u8]>> X25519<&x25519::PublicKey, NBytes<T>> for Context {
     fn x25519(&mut self, _pk: &x25519::PublicKey, encryption_key: NBytes<T>) -> Result<&mut Self> {
         self.size += x25519::PUBLIC_KEY_LENGTH + encryption_key.inner().as_ref().len();
         Ok(self)

--- a/spongos/src/ddml/commands/unwrap/x25519.rs
+++ b/spongos/src/ddml/commands/unwrap/x25519.rs
@@ -15,7 +15,7 @@ use crate::{
 /// secret key, computes the Diffie Hellman shared key. That key is then absorbed as an [`External`]
 /// [`NBytes`] object into the [`Context`]. The [`Context`] is committed, and the secret key is then
 /// decrypted from the byte stream.
-impl<'a, F: PRP, T: AsMut<[u8]>, IS: io::IStream> X25519<&'a x25519::SecretKey, NBytes<T>>
+impl<F: PRP, T: AsMut<[u8]>, IS: io::IStream> X25519<&x25519::SecretKey, NBytes<T>>
     for Context<IS, F>
 {
     fn x25519(

--- a/spongos/src/ddml/commands/wrap/x25519.rs
+++ b/spongos/src/ddml/commands/wrap/x25519.rs
@@ -21,7 +21,7 @@ use rand::{rngs::StdRng, SeedableRng};
 // X25519 wrap command requires randomly generating an x25519 keypair. Because of that, it can only
 // be compiled on architectures supported by `getrandom`.
 #[cfg(feature = "osrng")]
-impl<'a, F: PRP, T: AsRef<[u8]>, OS: io::OStream> X25519<&'a x25519::PublicKey, NBytes<T>>
+impl<F: PRP, T: AsRef<[u8]>, OS: io::OStream> X25519<&x25519::PublicKey, NBytes<T>>
     for Context<OS, F>
 {
     fn x25519(

--- a/streams/Cargo.toml
+++ b/streams/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = {version = "1", default-features = false, optional = true}
 [dev-dependencies]
 dotenv = {version = "0.15.0", default-features = false}
 hex = {version = "0.4.3", default-features = false}
+tokio = {version = "1.15", default-features = false}
 
 isocountry = { version = "0.3" }
 identity_demia = { git = "https://github.com/demia-protocol/identity.rs", branch="develop-demia", features = ["iota-client"]}
@@ -62,7 +63,7 @@ iota_stronghold = { git = "https://github.com/demia-protocol/stronghold.rs", bra
 iota-sdk = { git = "https://github.com/demia-protocol/node-network-sdk", branch="develop-demia", features = ["tls", "stronghold"] }
 
 rand = {version = "0.8.5", default-features = false, features = ["std", "std_rng"]}
-lets = {path = "../lets", features = ["tangle-client"]}
+lets = {path = "../lets", features = ["tangle-client", "bucket"]}
 textwrap = {version = "0.15.0", default-features = false}
 
 [[example]]

--- a/streams/README.md
+++ b/streams/README.md
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
         // instances, so there is no need to share any more than the original announcement message 
         let message = author.message()
             .with_topic(topic)
-            .with_payload(format!("Message #{}", i))
+            .with_payload(format!("Message #{i}"))
             .signed()
             .send()
             .await?;

--- a/streams/examples/full-example/scenarios/expired.rs
+++ b/streams/examples/full-example/scenarios/expired.rs
@@ -52,7 +52,7 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(
         .identifier()
         .expect("subscriber A should have identifier")
         .clone();
-    let subscriber_b_id = subscriber_b
+    let _subscriber_b_id = subscriber_b
         .identifier()
         .expect("subscriber B should have identifier")
         .clone();
@@ -75,7 +75,7 @@ pub(crate) async fn example<SR, T: GenericTransport<SR>>(
     print_user("Subscriber A", &subscriber_a);
 
     println!("> Author reads subscription of subscriber A");
-    let subscription_a_as_author = author
+    let _subscription_a_as_author = author
         .receive_message(subscription_a_as_a.address())
         .await?;
     print_user("Author", &author);

--- a/streams/src/api/cursor_store.rs
+++ b/streams/src/api/cursor_store.rs
@@ -223,7 +223,7 @@ impl fmt::Debug for InnerCursorStore {
         writeln!(f, "\t* latest link: {}", self.latest_link)?;
         writeln!(f, "\t* cursors:")?;
         for (id, cursor) in self.cursors.iter() {
-            writeln!(f, "\t\t{:?} => {}", id, cursor)?;
+            writeln!(f, "\t\t{id:?} => {cursor}")?;
         }
         Ok(())
     }
@@ -233,7 +233,7 @@ impl fmt::Debug for CursorStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "* branches:")?;
         for (topic, branch) in &self.0 {
-            writeln!(f, "{:?} => \n{:?}", topic, branch)?;
+            writeln!(f, "{topic:?} => \n{branch:?}")?;
         }
         Ok(())
     }

--- a/streams/src/api/messages.rs
+++ b/streams/src/api/messages.rs
@@ -276,7 +276,7 @@ impl<'a, T: Send + Sync> MessagesState<'a, T> {
 
     fn reset_stack(&mut self) {
         self.successful_round = false;
-        let filter = self.filter.clone();
+        let filter = self.filter;
         self.ids_stack = self
             .user
             .cursors()
@@ -468,11 +468,11 @@ mod tests {
         let timestamp_6 = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .expect("Failed to get system time")
-            .as_secs() as u64;
+            .as_secs();
 
         for i in 0..3 {
             std::thread::sleep(core::time::Duration::from_secs(1));
-            let p = format!("payload{}", i);
+            let p = format!("payload{i}");
             author
                 .send_signed_packet(branch_1, &p.as_bytes(), &p.as_bytes())
                 .await?;
@@ -482,14 +482,14 @@ mod tests {
         let timestamp_3 = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .expect("Failed to get system time")
-            .as_secs() as u64;
+            .as_secs();
 
         subscriber1.sync().await?;
         let backup = subscriber1.backup("messages_fetch_backwards").await?;
 
         for i in 3..6 {
             std::thread::sleep(core::time::Duration::from_secs(1));
-            let p = format!("payload{}", i);
+            let p = format!("payload{i}");
             let _packet = author
                 .send_signed_packet(branch_1, &p.as_bytes(), &p.as_bytes())
                 .await?;
@@ -536,7 +536,7 @@ mod tests {
                 .await?;
             let mut amount = 0;
             while let Some(Ok(msg)) = messages.next().await {
-                let p = format!("payload{}", amount);
+                let p = format!("payload{amount}");
                 assert!(msg.header().timestamp as u64 > timestamp_6);
                 assert_eq!(p.as_bytes(), msg.as_signed_packet().unwrap().masked_payload);
                 amount += 1;
@@ -583,7 +583,7 @@ mod tests {
                 .await?;
             let mut amount = 0;
             while let Some(Ok(msg)) = messages.next().await {
-                let p = format!("payload{}", amount);
+                let p = format!("payload{amount}");
                 assert!(msg.header().timestamp as u64 > timestamp_6);
                 assert_eq!(p.as_bytes(), msg.as_signed_packet().unwrap().masked_payload);
                 amount += 1;

--- a/streams/src/api/processing/announce.rs
+++ b/streams/src/api/processing/announce.rs
@@ -235,6 +235,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
+        #[cfg(feature = "did")] 
         let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
@@ -249,7 +250,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let branch_announcement = branch_announcement::Unwrap::new(&mut linked_msg_spongos, cache);
+        let branch_announcement = branch_announcement::Unwrap::new(&mut linked_msg_spongos, #[cfg(feature = "did")]  cache);
         let (message, spongos) = preparsed
             .unwrap(branch_announcement)
             .await

--- a/streams/src/api/processing/announce.rs
+++ b/streams/src/api/processing/announce.rs
@@ -235,7 +235,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
-
+        let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
             .header()
@@ -249,7 +249,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let branch_announcement = branch_announcement::Unwrap::new(&mut linked_msg_spongos);
+        let branch_announcement = branch_announcement::Unwrap::new(&mut linked_msg_spongos, cache);
         let (message, spongos) = preparsed
             .unwrap(branch_announcement)
             .await

--- a/streams/src/api/processing/keyload.rs
+++ b/streams/src/api/processing/keyload.rs
@@ -150,7 +150,8 @@ where
                 "send a keyload",
             ));
         }
-        
+
+        #[cfg(feature = "did")] 
         let cache = self.state.identity_doc_cache.clone();
 
         // Link message to edge of branch
@@ -196,7 +197,7 @@ where
             encryption_key,
             nonce,
             user_id,
-            cache,
+            #[cfg(feature = "did")] cache,
         ));
         let header = HDF::new(
             message_types::KEYLOAD,
@@ -303,6 +304,7 @@ where
             .collect();
 
         let user_id = self.state.user_id.as_mut();
+        #[cfg(feature = "did")] 
         let cache = self.state.identity_doc_cache.clone();
 
         // Retrieve public key and signature for Message return
@@ -315,7 +317,7 @@ where
             user_id,
             author_identifier,
             &self.state.psk_store,
-            cache
+            #[cfg(feature = "did")] cache,
         );
         let (message, spongos) = preparsed
             .unwrap(keyload)

--- a/streams/src/api/processing/keyload.rs
+++ b/streams/src/api/processing/keyload.rs
@@ -150,6 +150,8 @@ where
                 "send a keyload",
             ));
         }
+        
+        let cache = self.state.identity_doc_cache.clone();
 
         // Link message to edge of branch
         let link_to = self
@@ -194,6 +196,7 @@ where
             encryption_key,
             nonce,
             user_id,
+            cache,
         ));
         let header = HDF::new(
             message_types::KEYLOAD,
@@ -300,6 +303,7 @@ where
             .collect();
 
         let user_id = self.state.user_id.as_mut();
+        let cache = self.state.identity_doc_cache.clone();
 
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
@@ -311,6 +315,7 @@ where
             user_id,
             author_identifier,
             &self.state.psk_store,
+            cache
         );
         let (message, spongos) = preparsed
             .unwrap(keyload)

--- a/streams/src/api/processing/signed.rs
+++ b/streams/src/api/processing/signed.rs
@@ -192,7 +192,8 @@ where
         if changed {
             // lost permission
         }
-        
+
+        #[cfg(feature = "did")]
         let cache = self.state.identity_doc_cache.clone();
 
         // Unwrap message
@@ -208,7 +209,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let signed_packet = signed_packet::Unwrap::new(&mut linked_msg_spongos, cache);
+        let signed_packet = signed_packet::Unwrap::new(&mut linked_msg_spongos, #[cfg(feature = "did")]  cache);
         let (message, spongos) = preparsed
             .unwrap(signed_packet)
             .await

--- a/streams/src/api/processing/signed.rs
+++ b/streams/src/api/processing/signed.rs
@@ -192,6 +192,8 @@ where
         if changed {
             // lost permission
         }
+        
+        let cache = self.state.identity_doc_cache.clone();
 
         // Unwrap message
         let linked_msg_address = preparsed
@@ -206,7 +208,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let signed_packet = signed_packet::Unwrap::new(&mut linked_msg_spongos);
+        let signed_packet = signed_packet::Unwrap::new(&mut linked_msg_spongos, cache);
         let (message, spongos) = preparsed
             .unwrap(signed_packet)
             .await

--- a/streams/src/api/processing/subscription.rs
+++ b/streams/src/api/processing/subscription.rs
@@ -45,6 +45,7 @@ where
             &base_branch,
             SUB_MESSAGE_NUM,
         );
+        let cache = self.state.identity_doc_cache.clone();
 
         // Prepare HDF and PCF
         // Spongos must be copied because wrapping mutates it
@@ -68,6 +69,7 @@ where
             unsubscribe_key,
             user_id,
             &mut author_identifier,
+            cache
         ));
         let header = HDF::new(
             message_types::SUBSCRIPTION,
@@ -122,7 +124,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
-
+        let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
             .header()
@@ -140,7 +142,7 @@ where
             .identity_mut()
             .ok_or(Error::NoIdentity("Derive a secret key"))?;
 
-        let subscription = subscription::Unwrap::new(&mut linked_msg_spongos, user_id);
+        let subscription = subscription::Unwrap::new(&mut linked_msg_spongos, user_id, cache);
         let (message, _spongos) = preparsed
             .unwrap(subscription)
             .await

--- a/streams/src/api/processing/subscription.rs
+++ b/streams/src/api/processing/subscription.rs
@@ -45,6 +45,8 @@ where
             &base_branch,
             SUB_MESSAGE_NUM,
         );
+        
+        #[cfg(feature = "did")]
         let cache = self.state.identity_doc_cache.clone();
 
         // Prepare HDF and PCF
@@ -69,7 +71,7 @@ where
             unsubscribe_key,
             user_id,
             &mut author_identifier,
-            cache
+            #[cfg(feature = "did")] cache,
         ));
         let header = HDF::new(
             message_types::SUBSCRIPTION,
@@ -124,6 +126,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
+        #[cfg(feature = "did")]
         let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
@@ -142,7 +145,7 @@ where
             .identity_mut()
             .ok_or(Error::NoIdentity("Derive a secret key"))?;
 
-        let subscription = subscription::Unwrap::new(&mut linked_msg_spongos, user_id, cache);
+        let subscription = subscription::Unwrap::new(&mut linked_msg_spongos, user_id, #[cfg(feature = "did")]  cache);
         let (message, _spongos) = preparsed
             .unwrap(subscription)
             .await

--- a/streams/src/api/processing/unsubscription.rs
+++ b/streams/src/api/processing/unsubscription.rs
@@ -112,7 +112,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
-
+        let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
             .header()
@@ -126,7 +126,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let unsubscription = unsubscription::Unwrap::new(&mut linked_msg_spongos);
+        let unsubscription = unsubscription::Unwrap::new(&mut linked_msg_spongos, cache);
         let (message, spongos) = preparsed
             .unwrap(unsubscription)
             .await

--- a/streams/src/api/processing/unsubscription.rs
+++ b/streams/src/api/processing/unsubscription.rs
@@ -112,6 +112,7 @@ where
         // Retrieve public key and signature for Message return
         let pk = preparsed.transport_msg().pk().clone();
         let sig = preparsed.transport_msg().sig().clone();
+        #[cfg(feature = "did")]
         let cache = self.state.identity_doc_cache.clone();
         // Unwrap message
         let linked_msg_address = preparsed
@@ -126,7 +127,7 @@ where
                 return Ok(Message::orphan(address, pk, sig, preparsed));
             }
         };
-        let unsubscription = unsubscription::Unwrap::new(&mut linked_msg_spongos, cache);
+        let unsubscription = unsubscription::Unwrap::new(&mut linked_msg_spongos, #[cfg(feature = "did")]  cache);
         let (message, spongos) = preparsed
             .unwrap(unsubscription)
             .await

--- a/streams/src/api/selector.rs
+++ b/streams/src/api/selector.rs
@@ -60,6 +60,6 @@ impl Selector {
 
 impl core::fmt::Display for Selector {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", &self)
+        write!(f, "{self:?}")
     }
 }

--- a/streams/src/api/user.rs
+++ b/streams/src/api/user.rs
@@ -41,7 +41,7 @@ use lets::id::{
     did::{StrongholdSecretManager, DID},
     IdentityKind,
 };
-
+use lets::id::did::IdentityDocCache;
 // Local
 use crate::{
     api::{
@@ -113,6 +113,10 @@ pub(crate) struct State {
 
     /// List of known branch topics.
     pub(crate) topics: HashSet<Topic>,
+    
+    #[cfg(feature = "did")]
+    #[serde(skip)]
+    pub(crate) identity_doc_cache: IdentityDocCache
 }
 
 /// Public `API` Client for participation in a `Streams` channel.
@@ -164,6 +168,8 @@ impl<T> User<T> {
                 base_branch: Default::default(),
                 lean,
                 topics: Default::default(),
+                #[cfg(feature = "did")]
+                identity_doc_cache: IdentityDocCache::default(),
             },
         }
     }

--- a/streams/src/api/user.rs
+++ b/streams/src/api/user.rs
@@ -38,10 +38,9 @@ use spongos::{
 
 #[cfg(feature = "did")]
 use lets::id::{
-    did::{StrongholdSecretManager, DID},
+    did::{StrongholdSecretManager, DID, IdentityDocCache},
     IdentityKind,
 };
-use lets::id::did::IdentityDocCache;
 // Local
 use crate::{
     api::{
@@ -113,10 +112,10 @@ pub(crate) struct State {
 
     /// List of known branch topics.
     pub(crate) topics: HashSet<Topic>,
-    
+
     #[cfg(feature = "did")]
     #[serde(skip)]
-    pub(crate) identity_doc_cache: IdentityDocCache
+    pub(crate) identity_doc_cache: IdentityDocCache,
 }
 
 /// Public `API` Client for participation in a `Streams` channel.
@@ -621,7 +620,7 @@ where
     /// Start a [`Messages`] stream to traverse the channel messages
     ///
     /// See the documentation in [`Messages`] for more details and examples.
-    pub fn messages(&mut self) -> Messages<T> {
+    pub fn messages(&mut self) -> Messages<'_, T> {
         Messages::new(self)
     }
 
@@ -658,7 +657,7 @@ where
         &mut self,
         selector: &Selector,
         topic: impl Into<Topic>,
-    ) -> Result<Messages<T>> {
+    ) -> Result<Messages<'_, T>> {
         let topic = topic.into();
         let addr = AppAddr::gen(
             self.state.author_identifier.as_ref().unwrap(),
@@ -815,7 +814,7 @@ where
     }
 
     /// Create a new [`MessageBuilder`] instance.
-    pub fn message<P: Default>(&mut self) -> MessageBuilder<P, T> {
+    pub fn message<P: Default>(&mut self) -> MessageBuilder<'_, P, T> {
         MessageBuilder::new(self)
     }
 
@@ -1065,7 +1064,7 @@ impl<T> Debug for User<T> {
 
         writeln!(f, "* PSKs:")?;
         for pskid in self.state.psk_store.keys() {
-            writeln!(f, "\t<{:?}>", pskid)?;
+            writeln!(f, "\t<{pskid:?}>")?;
         }
 
         write!(f, "* lean: {}", self.state.lean)

--- a/streams/src/message/announcement.rs
+++ b/streams/src/message/announcement.rs
@@ -130,19 +130,11 @@ where
         #[cfg(feature = "did")]
         let mut cache = lets::id::did::IdentityDocCache::default();
         
-        let mut ctx = self.mask(&mut announcement.author_id)?
-            .mask(&mut announcement.topic)?;
-        
-        #[cfg(not(feature = "did"))]
-        {
-            ctx = ctx.verify(&announcement.author_id).await?;
-        }
-        #[cfg(feature = "did")]
-        {
-            ctx = ctx.verify(&announcement.author_id, &mut cache).await?;
-        }
-        
-        ctx.commit()?;
+        self.mask(&mut announcement.author_id)?
+            .mask(&mut announcement.topic)?
+            .verify(&announcement.author_id, #[cfg(feature = "did")] &mut cache)
+            .await?
+            .commit()?;
         Ok(self)
     }
 }

--- a/streams/src/message/branch_announcement.rs
+++ b/streams/src/message/branch_announcement.rs
@@ -33,7 +33,9 @@ use lets::{
         Topic,
     },
 };
+#[cfg(feature = "did")]
 use lets::id::did::IdentityDocCache;
+
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Commit, Join, Mask},
@@ -121,8 +123,7 @@ impl<'a> Unwrap<'a> {
     /// * `initial_state`: The initial [`Spongos`] state the message will be joined to
     pub(crate) fn new(
         initial_state: &'a mut Spongos,
-        #[cfg(feature = "did")]
-        cache: IdentityDocCache,
+        #[cfg(feature = "did")] cache: IdentityDocCache,
     ) -> Self {
         Self {
             initial_state,
@@ -153,7 +154,7 @@ where
         self.join(announcement.initial_state)?
             .mask(&mut author_id)?
             .mask(&mut announcement.new_topic)?
-            .verify(&author_id, &mut announcement.cache)
+            .verify(&author_id, #[cfg(feature = "did")] &mut announcement.cache)
             .await?
             .commit()?;
         Ok(self)

--- a/streams/src/message/message_types.rs
+++ b/streams/src/message/message_types.rs
@@ -91,7 +91,7 @@ mod tests {
             MessageType::try_from(3),
             Ok(MessageType::SignedPacket)
         ));
-        assert!(matches!(MessageType::try_from(7), Err(_)));
+        assert!(MessageType::try_from(7).is_err());
     }
 
     #[test]

--- a/streams/src/message/signed_packet.rs
+++ b/streams/src/message/signed_packet.rs
@@ -30,6 +30,7 @@ use lets::{
         ContentSign, ContentSignSizeof, ContentSizeof, ContentUnwrap, ContentVerify, ContentWrap,
     },
 };
+use lets::id::did::IdentityDocCache;
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Absorb, Join, Mask},
@@ -116,6 +117,8 @@ pub(crate) struct Unwrap<'a> {
     masked_payload: Vec<u8>,
     /// The [`Identifier`] of the publisher
     publisher_id: Identifier,
+    #[cfg(feature = "did")]
+    cache: IdentityDocCache
 }
 
 impl<'a> Unwrap<'a> {
@@ -123,12 +126,18 @@ impl<'a> Unwrap<'a> {
     ///
     /// # Arguments
     /// * `initial_state`: The base [`Spongos`] state that the message will be joined to
-    pub(crate) fn new(initial_state: &'a mut Spongos) -> Self {
+    pub(crate) fn new(
+        initial_state: &'a mut Spongos,
+        #[cfg(feature = "did")] 
+        cache: IdentityDocCache
+    ) -> Self {
         Self {
             initial_state,
             public_payload: Default::default(),
             masked_payload: Default::default(),
             publisher_id: Identifier::default(),
+            #[cfg(feature = "did")]
+            cache
         }
     }
 
@@ -158,7 +167,7 @@ where
             .mask(&mut signed_packet.publisher_id)?
             .absorb(Bytes::new(&mut signed_packet.public_payload))?
             .mask(Bytes::new(&mut signed_packet.masked_payload))?
-            .verify(&signed_packet.publisher_id)
+            .verify(&signed_packet.publisher_id, &mut signed_packet.cache)
             .await?;
         Ok(self)
     }

--- a/streams/src/message/signed_packet.rs
+++ b/streams/src/message/signed_packet.rs
@@ -24,13 +24,14 @@ use async_trait::async_trait;
 // IOTA
 
 // Streams
+#[cfg(feature = "did")]
+use lets::id::did::IdentityDocCache;
 use lets::{
     id::{Identifier, Identity},
     message::{
         ContentSign, ContentSignSizeof, ContentSizeof, ContentUnwrap, ContentVerify, ContentWrap,
     },
 };
-use lets::id::did::IdentityDocCache;
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Absorb, Join, Mask},
@@ -118,7 +119,7 @@ pub(crate) struct Unwrap<'a> {
     /// The [`Identifier`] of the publisher
     publisher_id: Identifier,
     #[cfg(feature = "did")]
-    cache: IdentityDocCache
+    cache: IdentityDocCache,
 }
 
 impl<'a> Unwrap<'a> {
@@ -128,8 +129,7 @@ impl<'a> Unwrap<'a> {
     /// * `initial_state`: The base [`Spongos`] state that the message will be joined to
     pub(crate) fn new(
         initial_state: &'a mut Spongos,
-        #[cfg(feature = "did")] 
-        cache: IdentityDocCache
+        #[cfg(feature = "did")] cache: IdentityDocCache,
     ) -> Self {
         Self {
             initial_state,
@@ -137,7 +137,7 @@ impl<'a> Unwrap<'a> {
             masked_payload: Default::default(),
             publisher_id: Identifier::default(),
             #[cfg(feature = "did")]
-            cache
+            cache,
         }
     }
 
@@ -167,7 +167,7 @@ where
             .mask(&mut signed_packet.publisher_id)?
             .absorb(Bytes::new(&mut signed_packet.public_payload))?
             .mask(Bytes::new(&mut signed_packet.masked_payload))?
-            .verify(&signed_packet.publisher_id, &mut signed_packet.cache)
+            .verify(&signed_packet.publisher_id, #[cfg(feature = "did")] &mut signed_packet.cache)
             .await?;
         Ok(self)
     }

--- a/streams/src/message/subscription.rs
+++ b/streams/src/message/subscription.rs
@@ -39,6 +39,7 @@ use lets::{
         ContentSizeof, ContentUnwrap, ContentVerify, ContentWrap,
     },
 };
+use lets::id::did::IdentityDocCache;
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Join, Mask},
@@ -58,6 +59,8 @@ pub(crate) struct Wrap<'a> {
     subscriber_id: &'a mut Identity,
     /// The authors [`x25519::PublicKey`]
     author_identifier: &'a mut Identifier,
+    #[cfg(feature = "did")]
+    cache: IdentityDocCache,
 }
 
 impl<'a> Wrap<'a> {
@@ -73,12 +76,16 @@ impl<'a> Wrap<'a> {
         unsubscribe_key: [u8; 32],
         subscriber_id: &'a mut Identity,
         author_identifier: &'a mut Identifier,
+        #[cfg(feature = "did")]
+        cache: IdentityDocCache,
     ) -> Self {
         Self {
             initial_state,
             unsubscribe_key,
             subscriber_id,
             author_identifier,
+            #[cfg(feature = "did")]
+            cache,
         }
     }
 }
@@ -124,6 +131,7 @@ where
             subscription.subscriber_id.identity_kind(),
             subscription.author_identifier,
             &subscription.unsubscribe_key,
+            &mut subscription.cache,
         )
         .await?;
         ctx.mask(subscription.subscriber_id.identifier())?
@@ -143,6 +151,8 @@ pub(crate) struct Unwrap<'a> {
     subscriber_identifier: Identifier,
     /// The author's [`Identity`]
     author_id: &'a mut Identity,
+    #[cfg(feature = "did")]
+    cache: IdentityDocCache
 }
 
 impl<'a> Unwrap<'a> {
@@ -151,12 +161,19 @@ impl<'a> Unwrap<'a> {
     /// # Arguments:
     /// * `initial_state`: The initial [`Spongos`] state the message will be joined to
     /// * `author_ke_sk`: The author's secret exchange key
-    pub(crate) fn new(initial_state: &'a mut Spongos, author_id: &'a mut Identity) -> Self {
+    pub(crate) fn new(
+        initial_state: &'a mut Spongos, 
+        author_id: &'a mut Identity,
+        #[cfg(feature = "did")]
+        cache: IdentityDocCache,
+    ) -> Self {
         Self {
             initial_state,
             unsubscribe_key: Default::default(),
             subscriber_identifier: Default::default(),
             author_id,
+            #[cfg(feature = "did")]
+            cache,
         }
     }
 
@@ -176,12 +193,25 @@ impl<'a, IS> ContentUnwrap<Unwrap<'a>> for unwrap::Context<IS>
 where
     IS: io::IStream + Send,
 {
+    #[cfg(not(feature = "did"))]
     async fn unwrap(&mut self, subscription: &mut Unwrap<'a>) -> Result<&mut Self> {
         let ctx = self.join(subscription.initial_state)?;
         ctx.decrypt(subscription.author_id, &mut subscription.unsubscribe_key)
             .await?
             .mask(&mut subscription.subscriber_identifier)?
             .verify(&subscription.subscriber_identifier)
+            .await?;
+        Ok(self)
+    }
+    
+    #[cfg(feature = "did")]
+    async fn unwrap(&mut self, subscription: &mut Unwrap<'a>) -> Result<&mut Self> {
+        let ctx = self.join(subscription.initial_state)?;
+        let mut cache = subscription.cache.clone();
+        ctx.decrypt(subscription.author_id, &mut subscription.unsubscribe_key, &mut cache)
+            .await?
+            .mask(&mut subscription.subscriber_identifier)?
+            .verify(&subscription.subscriber_identifier, &mut cache)
             .await?;
         Ok(self)
     }

--- a/streams/src/message/unsubscription.rs
+++ b/streams/src/message/unsubscription.rs
@@ -19,13 +19,14 @@ use async_trait::async_trait;
 // IOTA
 
 // Streams
+#[cfg(feature = "did")]
+use lets::id::did::IdentityDocCache;
 use lets::{
     id::{Identifier, Identity},
     message::{
         ContentSign, ContentSignSizeof, ContentSizeof, ContentUnwrap, ContentVerify, ContentWrap,
     },
 };
-use lets::id::did::IdentityDocCache;
 use spongos::{
     ddml::{
         commands::{sizeof, unwrap, wrap, Commit, Join, Mask},
@@ -103,13 +104,13 @@ impl<'a> Unwrap<'a> {
     /// * `initial_state`: The initial [`Spongos`] state the message will be joined to
     pub(crate) fn new(
         initial_state: &'a mut Spongos,
-        #[cfg(feature = "did")] 
-        cache: IdentityDocCache,
+        #[cfg(feature = "did")] cache: IdentityDocCache,
     ) -> Self {
         Self {
             initial_state,
             subscriber_id: Identifier::default(),
-            cache
+            #[cfg(feature = "did")]
+            cache,
         }
     }
 
@@ -133,7 +134,7 @@ where
         self.join(unsubscription.initial_state)?
             .mask(&mut unsubscription.subscriber_id)?
             .commit()?
-            .verify(&unsubscription.subscriber_id, &mut unsubscription.cache)
+            .verify(&unsubscription.subscriber_id, #[cfg(feature = "did")] &mut unsubscription.cache)
             .await?;
         Ok(self)
     }


### PR DESCRIPTION
# Description
Adds a cache for identity docs to stop the constant node querying for signature verification and decryption. 