### PR TITLE
fix: update prev_topic latest_link on new_branch send

### DIFF
--- a/streams/src/api/processing/announce.rs
+++ b/streams/src/api/processing/announce.rs
@@ -135,6 +135,9 @@ where
         self.state
             .cursor_store
             .set_latest_link(topic, address.relative());
+        self.state
+            .cursor_store
+            .set_latest_link(prev_topic, address.relative());
         Ok(SendResponse::new(address, send_response))
     }
 }


### PR DESCRIPTION
## Summary

`User::new_branch` (streams/src/api/processing/announce.rs) was updating `set_latest_link` only for the newly created topic, not for the previous topic. Because a branch announcement is the unique message that simultaneously tips two branches (it's the first message of the new branch AND the newest message on the prev branch), the prev branch's `latest_link` was left pointing at whatever preceded it — typically a signed packet — instead of the just-sent branch announcement.

This commit adds the missing `set_latest_link(prev_topic, address.relative())` alongside the existing update for the new topic.

## Why this matters — lean mode reads were broken for chained branch announcements

Scenario: `Announcement → SignedPacket → BranchAnn1 → BranchAnn2 → BranchAnn3`, all on the base branch.

On send, every new `BranchAnn` uses `get_latest_link(&prev_topic)` to pick its `linked_msg_address`. Before this fix, `prev_topic`'s latest link was never advanced past the `SignedPacket`, so BA1, BA2, and BA3 were all wrapped linking back to the **SignedPacket** spongos rather than chaining BA2→BA1 and BA3→BA2.

On the read side, the Demia State Manager runs in **lean mode**, which drops a message's spongos as soon as it has been consumed. The consequence:

1. Reader processes SignedPacket → SP spongos stored.
2. Reader processes BA1 (linked_msg = SP) → unwraps using SP spongos, then lean mode drops SP spongos.
3. Reader processes BA2 (linked_msg = SP again) → SP spongos is **gone**, unwrap fails, BA2 is returned as orphan.
4. Same failure for BA3.

Net effect: only the first branch announcement in the chain was ever processed; every subsequent BA on the base branch was dropped as an orphan, breaking the State Manager's view of the stream topology.

With this fix, the sender correctly chains BA2→BA1 and BA3→BA2. In lean mode the reader stores each BA's spongos immediately before the next BA consumes it, so the chain resolves cleanly.

## Scope of the audit

I audited every `set_latest_link` call site. All other processing paths (`signed.rs`, `tagged.rs`, `keyload.rs`, `handle_announcement`) handle messages that belong to a single topic, so their single-topic update is correct. `new_branch` was the only place where a message legitimately tips two branches, and therefore the only place this alignment was missing.

## Testing

Validated end-to-end using the data simulator together with the Demia State Manager, addressing Demia-Protocol/demia-user-state-manager#32.