### PR TITLE
reset: now with more reset

### DIFF
--- a/streams/src/api/cursor_store.rs
+++ b/streams/src/api/cursor_store.rs
@@ -137,15 +137,6 @@ impl CursorStore {
         self.0.get(topic).map(|inner| inner.cursors.iter())
     }
 
-    /// Reset every stored cursor to the initial stream position.
-    pub(crate) fn reset_cursors(&mut self) {
-        self.0.values_mut().for_each(|branch| {
-            branch.cursors.values_mut().for_each(|cursor| {
-                *cursor = INIT_MESSAGE_NUM;
-            });
-        });
-    }
-
     /// If the [`Permissioned`] [`Identifier`] is already in the map, and the permission is
     /// different, remove the old permission and keep the old cursor. Otherwise, insert the new
     /// permission and cursor
@@ -277,38 +268,5 @@ mod tests {
 
         assert!(branch_store.get_cursor(&topic_1, &identifier).is_none());
         assert!(branch_store.get_cursor(&topic_2, &identifier).is_none());
-    }
-
-    #[test]
-    fn branch_store_can_reset_all_cursors() {
-        let mut branch_store = CursorStore::new();
-        let identifier_1 = Identity::from(Ed25519::from_seed("identifier 1"))
-            .identifier()
-            .clone();
-        let identifier_2 = Identity::from(Ed25519::from_seed("identifier 2"))
-            .identifier()
-            .clone();
-        let permission_1 =
-            Permissioned::ReadWrite(identifier_1.clone(), PermissionDuration::Perpetual);
-        let permission_2 =
-            Permissioned::ReadWrite(identifier_2.clone(), PermissionDuration::Perpetual);
-        let topic_1 = Topic::new("topic 1".to_string());
-        let topic_2 = Topic::new("topic 2".to_string());
-
-        branch_store.new_branch(topic_1.clone());
-        branch_store.new_branch(topic_2.clone());
-        branch_store.insert_cursor(&topic_1, permission_1, 7);
-        branch_store.insert_cursor(&topic_2, permission_2, 13);
-
-        branch_store.reset_cursors();
-
-        assert_eq!(
-            branch_store.get_cursor(&topic_1, &identifier_1),
-            Some(crate::api::user::INIT_MESSAGE_NUM)
-        );
-        assert_eq!(
-            branch_store.get_cursor(&topic_2, &identifier_2),
-            Some(crate::api::user::INIT_MESSAGE_NUM)
-        );
     }
 }

--- a/streams/src/api/reset.rs
+++ b/streams/src/api/reset.rs
@@ -1,16 +1,104 @@
+// Streams
+use lets::id::Permissioned;
+
 // Local
+use crate::api::cursor_store::CursorStore;
+use crate::api::user::INIT_MESSAGE_NUM;
 use crate::{Error, Result, User};
 
 impl<T> User<T> {
-    /// Reset message cursors so the next sync reads messages from the beginning again.
+    /// Reset message processing state so the next sync reads messages from the beginning again.
     ///
-    /// This preserves identity, PSKs, subscribers, topics, latest links, and stored Spongos states.
-    /// Use this after adding newly available keys when messages may have been skipped because they
-    /// could not be decrypted.
+    /// This preserves identity, PSKs, subscribers, and the stream announcement anchor. Branches,
+    /// permissions, cursors, latest links, and message Spongos states are rebuilt by the next sync.
+    /// Use this after adding newly available keys when messages may previously have been skipped.
     pub fn reset_message_state(&mut self) -> Result<()> {
-        self.stream_address()
+        let stream_address = self
+            .stream_address()
             .ok_or(Error::NoStream("reset message state"))?;
-        self.state.cursor_store.reset_cursors();
+        let author_identifier = self
+            .state
+            .author_identifier
+            .clone()
+            .ok_or(Error::NoStream("reset message state"))?;
+        let base_branch = self.state.base_branch.clone();
+        let announcement_spongos = self
+            .state
+            .spongos_store
+            .get(&stream_address.relative())
+            .copied()
+            .ok_or(Error::MessageMissing(
+                stream_address.relative(),
+                "spongos store",
+            ))?;
+
+        self.state.cursor_store = CursorStore::new();
+        self.state.cursor_store.new_branch(base_branch.clone());
+        self.state.cursor_store.insert_cursor(
+            &base_branch,
+            Permissioned::Admin(author_identifier),
+            INIT_MESSAGE_NUM,
+        );
+        self.state
+            .cursor_store
+            .set_latest_link(base_branch.clone(), stream_address.relative());
+
+        self.state.topics.clear();
+        self.state.topics.insert(base_branch);
+
+        self.state.spongos_store.clear();
+        self.state
+            .spongos_store
+            .insert(stream_address.relative(), announcement_spongos);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::TryStreamExt;
+    use lets::{
+        id::{Ed25519, Psk},
+        transport::bucket,
+    };
+
+    use crate::{MessageContent, Result, User};
+
+    #[tokio::test]
+    async fn reset_replays_messages_after_adding_a_psk() -> Result<()> {
+        let transport = bucket::Client::new();
+        let psk = Psk::from_seed("retroactive psk");
+        let mut author = User::builder()
+            .with_identity(Ed25519::from_seed("author"))
+            .with_psk(psk.to_pskid(), psk)
+            .with_transport(transport.clone())
+            .build();
+        let announcement = author.create_stream("BASE_BRANCH").await?;
+        let mut reader = User::builder().lean().with_transport(transport).build();
+        reader.receive_message(announcement.address()).await?;
+
+        author.new_branch("BASE_BRANCH", "READINGS").await?;
+        author.send_keyload_for_all("READINGS").await?;
+        author
+            .send_signed_packet("READINGS", b"", b"reading")
+            .await?;
+
+        let initially_readable = reader.messages().try_collect::<Vec<_>>().await?;
+        assert!(!initially_readable
+            .iter()
+            .any(|message| matches!(message.content(), MessageContent::SignedPacket(_))));
+
+        assert!(reader.add_psk(psk));
+        reader.reset_message_state()?;
+
+        let replayed = reader.messages().try_collect::<Vec<_>>().await?;
+        assert!(replayed.iter().any(|message| {
+            message
+                .as_signed_packet()
+                .is_some_and(|packet| packet.masked_payload == b"reading")
+        }));
+
         Ok(())
     }
 }


### PR DESCRIPTION
Removes the old reset_cursors function.
replaces that with a more robust version that actually resets the state.

Previous code still kept latest link and spongos states.